### PR TITLE
Add forecast API call

### DIFF
--- a/app/src/main/java/com/halil/ozel/weatherapp/data/remote/ApiClient.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/data/remote/ApiClient.kt
@@ -7,7 +7,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object ApiClient {
     const val BASE_URL = "https://api.openweathermap.org/data/2.5/"
-    const val API_KEY = "3c074d933b6d1bd63550777fc2f76396"
+    const val API_KEY = "c0553ff6aecd1617c64d6d06ae65b79e"
 
     private val client: OkHttpClient by lazy {
         val interceptor = HttpLoggingInterceptor().apply {

--- a/app/src/main/java/com/halil/ozel/weatherapp/data/remote/WeatherService.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/data/remote/WeatherService.kt
@@ -17,4 +17,15 @@ interface WeatherService {
         @Query("units") units: String = "metric",
         @Query("appid") apiKey: String = ApiClient.API_KEY
     ): WeatherResponse
+
+    /**
+     * Fetch 5 day / 3 hour forecast data by city name.
+     * Using relative path here since BASE_URL already ends with `data/2.5/`.
+     */
+    @GET("forecast")
+    suspend fun getWeatherForecast(
+        @Query("q") cityName: String,
+        @Query("units") units: String = "metric",
+        @Query("appid") apiKey: String = ApiClient.API_KEY
+    ): WeatherResponse
 }


### PR DESCRIPTION
## Summary
- switch to a new API key
- expose `getWeatherForecast` in `WeatherService`

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5b9c998832bbbcd67f60989ba75