### PR TITLE
Implement weather forecast feature

### DIFF
--- a/app/src/main/java/com/halil/ozel/weatherapp/MainActivity.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/MainActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Column
+import com.halil.ozel.weatherapp.ui.screens.ForecastScreen
 import com.halil.ozel.weatherapp.ui.screens.WeatherScreen
 import com.halil.ozel.weatherapp.ui.theme.WeatherAppTheme
 
@@ -20,7 +22,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             WeatherAppTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    WeatherScreen(modifier = Modifier.padding(innerPadding))
+                    Column(modifier = Modifier.padding(innerPadding)) {
+                        WeatherScreen()
+                        ForecastScreen(cityName = "Ankara")
+                    }
                 }
             }
         }
@@ -30,6 +35,9 @@ class MainActivity : ComponentActivity() {
 @Preview(showBackground = true)
 @Composable
 fun DefaultPreview() {
-    WeatherAppTheme {
-        WeatherScreen()
-    }}
+    WeatherAppTheme {        Column {
+            WeatherScreen()
+            ForecastScreen(cityName = "Ankara")
+        }
+    }
+}

--- a/app/src/main/java/com/halil/ozel/weatherapp/data/remote/WeatherService.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/data/remote/WeatherService.kt
@@ -1,5 +1,6 @@
 package com.halil.ozel.weatherapp.data.remote
 
+import com.halil.ozel.weatherapp.model.ForecastResponse
 import com.halil.ozel.weatherapp.model.WeatherResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -27,5 +28,5 @@ interface WeatherService {
         @Query("q") cityName: String,
         @Query("units") units: String = "metric",
         @Query("appid") apiKey: String = ApiClient.API_KEY
-    ): WeatherResponse
+    ): ForecastResponse
 }

--- a/app/src/main/java/com/halil/ozel/weatherapp/model/ForecastModels.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/model/ForecastModels.kt
@@ -1,0 +1,18 @@
+package com.halil.ozel.weatherapp.model
+
+/** Response model for 5 day / 3 hour forecast API. */
+data class ForecastResponse(
+    val list: List<ForecastItem>
+)
+
+data class ForecastItem(
+    val dt: Long,
+    val main: ForecastMain,
+    val weather: List<WeatherDesc>
+)
+
+data class ForecastMain(
+    val temp: Double,
+    val temp_min: Double,
+    val temp_max: Double
+)

--- a/app/src/main/java/com/halil/ozel/weatherapp/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/repository/WeatherRepository.kt
@@ -1,6 +1,7 @@
 package com.halil.ozel.weatherapp.repository
 
 import com.halil.ozel.weatherapp.data.remote.ApiClient
+import com.halil.ozel.weatherapp.model.ForecastResponse
 import com.halil.ozel.weatherapp.model.WeatherResponse
 
 class WeatherRepository {
@@ -8,5 +9,9 @@ class WeatherRepository {
 
     suspend fun getWeather(lat: Double, lon: Double): WeatherResponse {
         return service.fetchWeather(lat, lon)
+    }
+
+    suspend fun getForecast(cityName: String): ForecastResponse {
+        return service.getWeatherForecast(cityName)
     }
 }

--- a/app/src/main/java/com/halil/ozel/weatherapp/ui/screens/ForecastScreen.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/ui/screens/ForecastScreen.kt
@@ -1,0 +1,71 @@
+package com.halil.ozel.weatherapp.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.halil.ozel.weatherapp.model.ForecastItem
+import com.halil.ozel.weatherapp.viewmodel.ForecastViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun ForecastScreen(
+    cityName: String,
+    modifier: Modifier = Modifier,
+    viewModel: ForecastViewModel = viewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(cityName) {
+        viewModel.loadForecast(cityName)
+    }
+
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        when {
+            state.isLoading -> CircularProgressIndicator()
+            state.data != null -> ForecastContent(state.data!!.list)
+            state.error != null -> Text(text = state.error ?: "Error")
+        }
+    }
+}
+
+@Composable
+private fun ForecastContent(items: List<ForecastItem>) {
+    LazyColumn(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        items(items) { item ->
+            ForecastRow(item)
+        }
+    }
+}
+
+@Composable
+private fun ForecastRow(item: ForecastItem) {
+    val icon = item.weather.firstOrNull()?.icon ?: "01d"
+    val iconUrl = "https://openweathermap.org/img/wn/${'$'}icon@2x.png"
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+    ) {
+        Text(
+            text = SimpleDateFormat("dd MMM HH:mm", Locale.getDefault())
+                .format(Date(item.dt * 1000)),
+            modifier = Modifier.weight(1f)
+        )
+        AsyncImage(model = iconUrl, contentDescription = null, modifier = Modifier.size(40.dp))
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = "${'$'}{item.main.temp.toInt()}°C", style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/app/src/main/java/com/halil/ozel/weatherapp/viewmodel/ForecastViewModel.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/viewmodel/ForecastViewModel.kt
@@ -1,0 +1,37 @@
+package com.halil.ozel.weatherapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.halil.ozel.weatherapp.model.ForecastResponse
+import com.halil.ozel.weatherapp.repository.WeatherRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** State for forecast UI. */
+data class ForecastUiState(
+    val isLoading: Boolean = false,
+    val data: ForecastResponse? = null,
+    val error: String? = null
+)
+
+class ForecastViewModel(
+    private val repository: WeatherRepository = WeatherRepository()
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ForecastUiState())
+    val state: StateFlow<ForecastUiState> = _state
+
+    /** Fetch forecast data for the given city name. */
+    fun loadForecast(cityName: String) {
+        _state.value = ForecastUiState(isLoading = true)
+        viewModelScope.launch {
+            try {
+                val response = repository.getForecast(cityName)
+                _state.value = ForecastUiState(data = response)
+            } catch (e: Exception) {
+                _state.value = ForecastUiState(error = e.localizedMessage)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create models for 5-day forecast
- expose forecast endpoint in `WeatherService`
- add repository method for forecast
- implement `ForecastViewModel` and `ForecastScreen`
- display forecast in `MainActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686ea7132048832b9869d93338bd6549