### PR TITLE
Add city list screen and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This sample shows how to fetch a 5 day / 3 hour weather forecast from the OpenWe
 2. Open `ApiClient.kt` and replace `"YOUR_API_KEY"` with your API key.
 3. Build and run the project using Android Studio.
 
-The main screen displays a list of upcoming forecast entries with icons and temperatures.
+The app now shows a list of sample cities from around the world. Selecting a city opens
+its 5 day / 3 hour forecast complete with weather icons.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.icons.extended)
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson)
     implementation(libs.okhttp.logging)

--- a/app/src/main/java/com/halil/ozel/weatherapp/MainActivity.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/MainActivity.kt
@@ -8,10 +8,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import com.halil.ozel.weatherapp.ui.screens.ForecastScreen
+import com.halil.ozel.weatherapp.ui.screens.CityListScreen
 import com.halil.ozel.weatherapp.ui.theme.WeatherAppTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,9 +25,21 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             WeatherAppTheme {
+                var currentScreen by remember { mutableStateOf<Screen>(Screen.CityList) }
+
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Column(modifier = Modifier.padding(innerPadding)) {
-                        ForecastScreen(cityName = "Ankara")
+                    when (val screen = currentScreen) {
+                        Screen.CityList ->
+                            CityListScreen(
+                                modifier = Modifier.padding(innerPadding),
+                                onCitySelected = { city -> currentScreen = Screen.Forecast(city) }
+                            )
+                        is Screen.Forecast ->
+                            ForecastScreen(
+                                cityName = screen.city,
+                                modifier = Modifier.padding(innerPadding),
+                                onBack = { currentScreen = Screen.CityList }
+                            )
                     }
                 }
             }
@@ -30,11 +47,16 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+private sealed interface Screen {
+    object CityList : Screen
+    data class Forecast(val city: String) : Screen
+}
+
 @Preview(showBackground = true)
 @Composable
 fun DefaultPreview() {
     WeatherAppTheme {
         Column {
-            ForecastScreen(cityName = "Ankara")
+            CityListScreen(onCitySelected = {})
         }
     }}

--- a/app/src/main/java/com/halil/ozel/weatherapp/ui/screens/CityListScreen.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/ui/screens/CityListScreen.kt
@@ -1,0 +1,43 @@
+package com.halil.ozel.weatherapp.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CityListScreen(
+    modifier: Modifier = Modifier,
+    onCitySelected: (String) -> Unit
+) {
+    val cities = listOf("Ankara", "London", "New York", "Tokyo", "Paris")
+    LazyColumn(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        items(cities) { city ->
+            CityRow(city = city, onClick = { onCitySelected(city) })
+        }
+    }
+}
+
+@Composable
+private fun CityRow(city: String, onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = 12.dp)
+    ) {
+        Icon(imageVector = Icons.Default.Public, contentDescription = null)
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(text = city, style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/app/src/main/java/com/halil/ozel/weatherapp/ui/screens/ForecastScreen.kt
+++ b/app/src/main/java/com/halil/ozel/weatherapp/ui/screens/ForecastScreen.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -25,7 +29,8 @@ import java.util.Locale
 fun ForecastScreen(
     cityName: String,
     modifier: Modifier = Modifier,
-    viewModel: ForecastViewModel = viewModel()
+    viewModel: ForecastViewModel = viewModel(),
+    onBack: (() -> Unit)? = null
 ) {
     val state by viewModel.state.collectAsState()
 
@@ -33,11 +38,26 @@ fun ForecastScreen(
         viewModel.loadForecast(cityName)
     }
 
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        when {
-            state.isLoading -> CircularProgressIndicator()
-            state.data != null -> ForecastContent(state.data!!.list)
-            state.error != null -> Text(text = state.error ?: "Error")
+    Column(modifier = modifier.fillMaxSize()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().padding(16.dp)
+        ) {
+            if (onBack != null) {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Text(text = cityName, style = MaterialTheme.typography.titleLarge)
+        }
+
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            when {
+                state.isLoading -> CircularProgressIndicator()
+                state.data != null -> ForecastContent(state.data!!.list)
+                state.error != null -> Text(text = state.error ?: "Error")
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttpLogging" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+androidx-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- show a list of sample cities
- navigate to forecast screen when a city is tapped
- add back navigation on the forecast screen
- include material icons dependency
- update README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686eb09bac78832bb008ce251d8208dc